### PR TITLE
Fix #45 unread badges persisting after read, fix #44 add realtime rea…

### DIFF
--- a/Librecord.Api/Controllers/Messaging/ReactionController.cs
+++ b/Librecord.Api/Controllers/Messaging/ReactionController.cs
@@ -1,7 +1,8 @@
-using System.Security.Claims;
+using Librecord.Api.Hubs;
 using Librecord.Application.Messaging;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 
 namespace Librecord.Api.Controllers.Messaging;
 
@@ -11,11 +12,19 @@ namespace Librecord.Api.Controllers.Messaging;
 public class ReactionController : AuthenticatedController
 {
     private readonly IReactionService _reactions;
+    private readonly IHubContext<DmHub> _dmHub;
+    private readonly IHubContext<GuildHub> _guildHub;
 
-    public ReactionController(IReactionService reactions)
+    public ReactionController(
+        IReactionService reactions,
+        IHubContext<DmHub> dmHub,
+        IHubContext<GuildHub> guildHub)
     {
         _reactions = reactions;
+        _dmHub = dmHub;
+        _guildHub = guildHub;
     }
+
     // ---------------------------------------------------------
     // ADD REACTION
     // ---------------------------------------------------------
@@ -25,6 +34,16 @@ public class ReactionController : AuthenticatedController
         try
         {
             var reaction = await _reactions.AddReactionAsync(messageId, UserId, emoji);
+
+            var channelId = await _reactions.GetMessageChannelIdAsync(messageId);
+            if (channelId.HasValue)
+            {
+                var payload = new { channelId = channelId.Value, messageId, userId = UserId, emoji = reaction.Emoji };
+                await Task.WhenAll(
+                    _dmHub.Clients.Group(DmHub.ChannelGroup(channelId.Value)).SendAsync("channel:reaction:added", payload),
+                    _guildHub.Clients.Group(GuildHub.ChannelGroup(channelId.Value)).SendAsync("channel:reaction:added", payload));
+            }
+
             return Ok(new
             {
                 messageId = reaction.MessageId,
@@ -45,6 +64,16 @@ public class ReactionController : AuthenticatedController
     public async Task<IActionResult> Remove(Guid messageId, string emoji)
     {
         await _reactions.RemoveReactionAsync(messageId, UserId, emoji);
+
+        var channelId = await _reactions.GetMessageChannelIdAsync(messageId);
+        if (channelId.HasValue)
+        {
+            var payload = new { channelId = channelId.Value, messageId, userId = UserId, emoji };
+            await Task.WhenAll(
+                _dmHub.Clients.Group(DmHub.ChannelGroup(channelId.Value)).SendAsync("channel:reaction:removed", payload),
+                _guildHub.Clients.Group(GuildHub.ChannelGroup(channelId.Value)).SendAsync("channel:reaction:removed", payload));
+        }
+
         return Ok();
     }
 }

--- a/Librecord.Application/Messaging/IReactionService.cs
+++ b/Librecord.Application/Messaging/IReactionService.cs
@@ -6,4 +6,5 @@ public interface IReactionService
 {
     Task<MessageReaction> AddReactionAsync(Guid messageId, Guid userId, string emoji);
     Task RemoveReactionAsync(Guid messageId, Guid userId, string emoji);
+    Task<Guid?> GetMessageChannelIdAsync(Guid messageId);
 }

--- a/Librecord.Application/Messaging/ReactionService.cs
+++ b/Librecord.Application/Messaging/ReactionService.cs
@@ -39,4 +39,9 @@ public class ReactionService : IReactionService
         await _reactions.RemoveAsync(messageId, userId, emoji);
         await _reactions.SaveChangesAsync();
     }
+
+    public Task<Guid?> GetMessageChannelIdAsync(Guid messageId)
+    {
+        return _reactions.GetMessageChannelIdAsync(messageId);
+    }
 }

--- a/Librecord.Client/src/components/layout/ChannelSidebar.tsx
+++ b/Librecord.Client/src/components/layout/ChannelSidebar.tsx
@@ -164,10 +164,16 @@ export default function ChannelSidebar({ guildId }: Props) {
         return () => window.removeEventListener("guild:message:ping", onPing as EventListener);
     }, [channelId, user?.userId]);
 
-    // Derive effective unreads — clear count for the active channel
-    const effectiveUnreads = channelId
-        ? Object.fromEntries(Object.entries(unreads).filter(([k]) => k !== channelId))
-        : unreads;
+    // Clear unread count when navigating into a channel (render-phase)
+    const [prevActiveChannelId, setPrevActiveChannelId] = useState(channelId);
+    if (channelId && channelId !== prevActiveChannelId) {
+        setPrevActiveChannelId(channelId);
+        if (unreads[channelId]) {
+            const next = { ...unreads };
+            delete next[channelId];
+            setUnreads(next);
+        }
+    }
 
     async function handleCreateChannel(data: {
         name: string;
@@ -202,7 +208,7 @@ export default function ChannelSidebar({ guildId }: Props) {
                                 )}
                             </div>
                             {textChannels.map(ch => {
-                                const unreadCount = effectiveUnreads[ch.id] ?? 0;
+                                const unreadCount = unreads[ch.id] ?? 0;
                                 const isActive = channelId === ch.id;
                                 const hasUnread = unreadCount > 0 && !isActive;
 

--- a/Librecord.Client/src/components/layout/DmSidebar.tsx
+++ b/Librecord.Client/src/components/layout/DmSidebar.tsx
@@ -171,10 +171,16 @@ export default function DmSidebar() {
         return () => window.removeEventListener("dm:message:ping", onPing as EventListener);
     }, [dmId, user?.userId, loadDms]);
 
-    // Derive effective unreads — clear count for the active channel
-    const effectiveUnreads = dmId
-        ? Object.fromEntries(Object.entries(unreads).filter(([k]) => k !== dmId))
-        : unreads;
+    // Clear unread count when navigating into a DM (render-phase)
+    const [prevActiveDmId, setPrevActiveDmId] = useState(dmId);
+    if (dmId && dmId !== prevActiveDmId) {
+        setPrevActiveDmId(dmId);
+        if (unreads[dmId]) {
+            const next = { ...unreads };
+            delete next[dmId];
+            setUnreads(next);
+        }
+    }
 
     return (
         <>
@@ -219,7 +225,7 @@ export default function DmSidebar() {
 
                     const showAvatar = others.length === 1;
                     const avatar = showAvatar ? getAvatarUrl(others[0].avatarUrl) : undefined;
-                    const unreadCount = effectiveUnreads[dm.id] ?? 0;
+                    const unreadCount = unreads[dm.id] ?? 0;
                     const otherStatus = showAvatar ? (presenceMap[others[0].id] ?? "offline") : undefined;
 
                     return (

--- a/Librecord.Client/src/pages/dm/DmConversationPage.tsx
+++ b/Librecord.Client/src/pages/dm/DmConversationPage.tsx
@@ -251,6 +251,49 @@ export default function DmConversationPage() {
     }, [dmId]);
 
     /* ------------------------------------------------------------------ */
+    /* REALTIME: REACTIONS                                                  */
+    /* ------------------------------------------------------------------ */
+
+    useEffect(() => {
+        if (!dmId) return;
+
+        const onAdded = (event: CustomEvent<DmEventMap["channel:reaction:added"]>) => {
+            const { channelId, messageId, userId: reactUserId, emoji } = event.detail;
+            if (channelId !== dmId) return;
+            if (reactUserId === user?.userId) return;
+
+            setMessages(prev =>
+                prev.map(m => {
+                    if (m.id !== messageId) return m;
+                    if (m.reactions.some(r => r.userId === reactUserId && r.emoji === emoji)) return m;
+                    return { ...m, reactions: [...m.reactions, { userId: reactUserId, emoji, createdAt: new Date().toISOString() }] };
+                })
+            );
+        };
+
+        const onRemoved = (event: CustomEvent<DmEventMap["channel:reaction:removed"]>) => {
+            const { channelId, messageId, userId: reactUserId, emoji } = event.detail;
+            if (channelId !== dmId) return;
+            if (reactUserId === user?.userId) return;
+
+            setMessages(prev =>
+                prev.map(m =>
+                    m.id === messageId
+                        ? { ...m, reactions: m.reactions.filter(r => !(r.userId === reactUserId && r.emoji === emoji)) }
+                        : m
+                )
+            );
+        };
+
+        window.addEventListener("channel:reaction:added", onAdded as EventListener);
+        window.addEventListener("channel:reaction:removed", onRemoved as EventListener);
+        return () => {
+            window.removeEventListener("channel:reaction:added", onAdded as EventListener);
+            window.removeEventListener("channel:reaction:removed", onRemoved as EventListener);
+        };
+    }, [dmId, user?.userId]);
+
+    /* ------------------------------------------------------------------ */
     /* LOAD CHANNEL + INITIAL MESSAGES                                     */
     /* ------------------------------------------------------------------ */
 

--- a/Librecord.Client/src/pages/guild/GuildPage.tsx
+++ b/Librecord.Client/src/pages/guild/GuildPage.tsx
@@ -253,6 +253,49 @@ export default function GuildChannelPage() {
     }, [channelId]);
 
     /* ------------------------------------------------------------------ */
+    /* REALTIME: REACTIONS                                                  */
+    /* ------------------------------------------------------------------ */
+
+    useEffect(() => {
+        if (!channelId) return;
+
+        const onAdded = (event: CustomEvent<GuildEventMap["channel:reaction:added"]>) => {
+            const { channelId: evtChannel, messageId, userId: reactUserId, emoji } = event.detail;
+            if (evtChannel !== channelId) return;
+            if (reactUserId === user?.userId) return; // already handled optimistically
+
+            setMessages(prev =>
+                prev.map(m => {
+                    if (m.id !== messageId) return m;
+                    if (m.reactions.some(r => r.userId === reactUserId && r.emoji === emoji)) return m;
+                    return { ...m, reactions: [...m.reactions, { userId: reactUserId, emoji, createdAt: new Date().toISOString() }] };
+                })
+            );
+        };
+
+        const onRemoved = (event: CustomEvent<GuildEventMap["channel:reaction:removed"]>) => {
+            const { channelId: evtChannel, messageId, userId: reactUserId, emoji } = event.detail;
+            if (evtChannel !== channelId) return;
+            if (reactUserId === user?.userId) return;
+
+            setMessages(prev =>
+                prev.map(m =>
+                    m.id === messageId
+                        ? { ...m, reactions: m.reactions.filter(r => !(r.userId === reactUserId && r.emoji === emoji)) }
+                        : m
+                )
+            );
+        };
+
+        window.addEventListener("channel:reaction:added", onAdded as EventListener);
+        window.addEventListener("channel:reaction:removed", onRemoved as EventListener);
+        return () => {
+            window.removeEventListener("channel:reaction:added", onAdded as EventListener);
+            window.removeEventListener("channel:reaction:removed", onRemoved as EventListener);
+        };
+    }, [channelId, user?.userId]);
+
+    /* ------------------------------------------------------------------ */
     /* LOAD CHANNEL + INITIAL MESSAGES                                     */
     /* ------------------------------------------------------------------ */
 

--- a/Librecord.Client/src/realtime/dm/dmEvents.ts
+++ b/Librecord.Client/src/realtime/dm/dmEvents.ts
@@ -88,4 +88,18 @@ export interface DmEventMap {
     "dm:channel:created": {
         channelId: string;
     };
+
+    "channel:reaction:added": {
+        channelId: string;
+        messageId: string;
+        userId: string;
+        emoji: string;
+    };
+
+    "channel:reaction:removed": {
+        channelId: string;
+        messageId: string;
+        userId: string;
+        emoji: string;
+    };
 }

--- a/Librecord.Client/src/realtime/dm/dmListeners.ts
+++ b/Librecord.Client/src/realtime/dm/dmListeners.ts
@@ -7,6 +7,7 @@ import type {
     DmRealtimeMessageDeletedTransport,
     DmRealtimeReadStateUpdatedTransport,
 } from "./dmTypes";
+import type { DmEventMap } from "./dmEvents";
 
 export function registerDmListeners() {
 
@@ -29,6 +30,8 @@ export function registerDmListeners() {
     dmConnection.off("channel:message:unpinned");
     dmConnection.off("dm:member:left");
     dmConnection.off("dm:channel:created");
+    dmConnection.off("channel:reaction:added");
+    dmConnection.off("channel:reaction:removed");
 
     /* ------------------------------------------------------------------ */
     /* MESSAGE PING (lightweight — for unread badges + notifications)      */
@@ -161,6 +164,23 @@ export function registerDmListeners() {
         "channel:message:unpinned",
         (payload: { channelId: string; messageId: string }) => {
             dispatchDmEvent("channel:message:unpinned", payload);
+        }
+    );
+
+    /* ------------------------------------------------------------------ */
+    /* REACTIONS                                                            */
+    /* ------------------------------------------------------------------ */
+    dmConnection.on(
+        "channel:reaction:added",
+        (payload: DmEventMap["channel:reaction:added"]) => {
+            dispatchDmEvent("channel:reaction:added", payload);
+        }
+    );
+
+    dmConnection.on(
+        "channel:reaction:removed",
+        (payload: DmEventMap["channel:reaction:removed"]) => {
+            dispatchDmEvent("channel:reaction:removed", payload);
         }
     );
 

--- a/Librecord.Client/src/realtime/guild/guildEvents.ts
+++ b/Librecord.Client/src/realtime/guild/guildEvents.ts
@@ -91,4 +91,18 @@ export interface GuildEventMap {
         channelId: string;
         messageId: string;
     };
+
+    "channel:reaction:added": {
+        channelId: string;
+        messageId: string;
+        userId: string;
+        emoji: string;
+    };
+
+    "channel:reaction:removed": {
+        channelId: string;
+        messageId: string;
+        userId: string;
+        emoji: string;
+    };
 }

--- a/Librecord.Client/src/realtime/guild/guildListeners.ts
+++ b/Librecord.Client/src/realtime/guild/guildListeners.ts
@@ -29,6 +29,8 @@ export function registerGuildListeners() {
     guildConnection.off("voice:user:state");
     guildConnection.off("channel:message:pinned");
     guildConnection.off("channel:message:unpinned");
+    guildConnection.off("channel:reaction:added");
+    guildConnection.off("channel:reaction:removed");
 
     /* ------------------------------------------------------------------ */
     /* MESSAGE PING (lightweight — for unread badges + notifications)      */
@@ -138,6 +140,23 @@ export function registerGuildListeners() {
         "channel:message:unpinned",
         (payload: { channelId: string; messageId: string }) => {
             dispatchGuildEvent("channel:message:unpinned", payload);
+        }
+    );
+
+    /* ------------------------------------------------------------------ */
+    /* REACTIONS                                                            */
+    /* ------------------------------------------------------------------ */
+    guildConnection.on(
+        "channel:reaction:added",
+        (payload: GuildEventMap["channel:reaction:added"]) => {
+            dispatchGuildEvent("channel:reaction:added", payload);
+        }
+    );
+
+    guildConnection.on(
+        "channel:reaction:removed",
+        (payload: GuildEventMap["channel:reaction:removed"]) => {
+            dispatchGuildEvent("channel:reaction:removed", payload);
         }
     );
 

--- a/Librecord.Domain/Messaging/Common/IReactionRepository.cs
+++ b/Librecord.Domain/Messaging/Common/IReactionRepository.cs
@@ -7,4 +7,5 @@ public interface IReactionRepository
     Task AddAsync(MessageReaction reaction);
     Task RemoveAsync(Guid messageId, Guid userId, string emoji);
     Task SaveChangesAsync();
+    Task<Guid?> GetMessageChannelIdAsync(Guid messageId);
 }

--- a/Librecord.Infra/Repositories/ReactionRepository.cs
+++ b/Librecord.Infra/Repositories/ReactionRepository.cs
@@ -47,4 +47,19 @@ public class ReactionRepository : IReactionRepository
     {
         return _db.SaveChangesAsync();
     }
+
+    public async Task<Guid?> GetMessageChannelIdAsync(Guid messageId)
+    {
+        // Check guild context first, then DM context
+        var guildCtx = await _db.GuildChannelMessages
+            .Where(g => g.MessageId == messageId)
+            .Select(g => (Guid?)g.ChannelId)
+            .FirstOrDefaultAsync();
+        if (guildCtx.HasValue) return guildCtx.Value;
+
+        return await _db.DmChannelMessages
+            .Where(d => d.MessageId == messageId)
+            .Select(d => (Guid?)d.ChannelId)
+            .FirstOrDefaultAsync();
+    }
 }

--- a/PLAN.md
+++ b/PLAN.md
@@ -10,7 +10,7 @@ Prioritized roadmap combining open GitHub issues and remaining codebase weakness
 - **#45** New message bubbles inconsistent — unread badges appear/disappear unreliably, persist after reading
 - **#44** Guild reaction resets chat position — adding/removing reaction scrolls to bottom after refresh
 - **#31** DM scroll position — resets to last text message instead of last item (media)
-- **#32** New DM from unknown user — first message from new user doesn't appear (partially fixed, needs testing)
+- ~~**#32** New DM from unknown user~~ — **Fixed.** Backend now notifies both sender and target via `dm:channel:created`; sidebar re-fetches on ping for closed DMs
 
 ### Pin bugs
 - **#15** Pin message content not showing — decryption fix deployed, needs verification
@@ -31,8 +31,8 @@ Prioritized roadmap combining open GitHub issues and remaining codebase weakness
 ## P1 — Features (next sprint)
 
 ### Social
-- **#21** Cancel friend request — add cancel button on outgoing requests
-- **#39** Delete friend's DM — button to remove 1-on-1 DM from sidebar
+- ~~**#21** Cancel friend request~~ — **Done.** Cancel button on outgoing requests, realtime sync to both users
+- ~~**#39** Delete friend's DM~~ — **Done.** Close button hides 1-on-1 DM; DM reappears when new message arrives
 
 ### Guild management
 - **#18** Kick/Ban UI — backend exists, need frontend buttons in member list
@@ -44,12 +44,12 @@ Prioritized roadmap combining open GitHub issues and remaining codebase weakness
 ### Messaging features
 - **#43** Reply system — reply to specific message with highlight/quote
 - **#42** Thread UI — backend complete, wire up ThreadPanel to GuildPage
-- **#34** Reaction popup z-index — popup overflows below message input
+- ~~**#34** Reaction popup z-index~~ — **Fixed.** z-index corrected, E2E test updated
 
 ### Upload UX
-- **#35** File upload loading indicator — "Uploading..." added, needs testing
-- **#36** File lost on refresh — beforeunload warning added, needs testing
-- **#37** Failed upload toast — error toast added, needs testing
+- ~~**#35** File upload loading indicator~~ — **Done.** "Uploading..." indicator, verified by E2E
+- ~~**#36** File lost on refresh~~ — **Done.** beforeunload warning, verified by E2E
+- ~~**#37** Failed upload toast~~ — **Done.** Error toast on failed upload, verified by E2E
 
 ---
 
@@ -83,7 +83,7 @@ Prioritized roadmap combining open GitHub issues and remaining codebase weakness
 3. #47 (upload cancel stuck) — blocks file uploads after cancel
 
 **Week 2 — Features users are asking for:**
-1. #21 (cancel friend request) + #39 (delete DM)
+1. ~~#21 (cancel friend request) + #39 (delete DM)~~ — **Done**
 2. #18 + #17 (kick/ban + role assignment) — guild management basics
 3. #13 + #12 (channel settings + server settings access)
 


### PR DESCRIPTION
…ctions

#45: Unread badges now clear from state when navigating to a channel instead of just being filtered out for display. Prevents stale counts from reappearing when navigating away.

#44: Reactions are now broadcast in realtime via SignalR. Added channel:reaction:added/removed events to both guild and DM hubs, with frontend listeners and handlers that skip own reactions (already handled optimistically). Updated PLAN.md with completed items.